### PR TITLE
Refactor icon retrieval and assignment logic

### DIFF
--- a/Win32 Apps/Commercial_Vantage/New-CommercialVantageWin32.ps1
+++ b/Win32 Apps/Commercial_Vantage/New-CommercialVantageWin32.ps1
@@ -260,41 +260,7 @@ try
 
     Write-Verbose "Parsed app version: $appVersion"
 
-    # Add Win32 App
-    $appParams = @{
-        FilePath                  = $intuneWinFile.Path
-        DisplayName               = $Config.DisplayName
-        Description               = $Config.Description
-        Publisher                 = $Config.Publisher
-        AppVersion                = $appVersion
-        InformationURL            = $Config.InformationURL
-        InstallExperience         = "system"
-        RequirementRule           = $requirementRule
-        AdditionalRequirementRule = $requirementRegistryRule
-        RestartBehavior           = "basedOnReturnCode"
-        DetectionRule             = $detectionRule
-        InstallCommandLine        = $installCommandLine
-        UninstallCommandLine      = $uninstallCommandLine
-    }
-
-    Write-Verbose "Adding Win32 app to Intune..."
-
-    $addAppParams = @{
-            ErrorAction = 'Stop'
-    }
-
-    if ($UseAzCopy) {
-    $addAppParams['UseAzCopy']         = $true
-    $addAppParams['AzCopyWindowStyle'] = 'hidden'
-    }
-
-    $intuneApp = Add-IntuneWin32App @appParams @addAppParams -Verbose
-    #$intuneApp = Add-IntuneWin32App @appParams -ErrorAction Stop -UseAzCopy -AzCopyWindowStyle hidden -Verbose #6>$null #-UseAzCopy -AzCopyWindowStyle hidden -UseAzCopy
-    Write-Verbose "Win32 app added successfully. App ID: $($intuneApp.id)"
-
-
-#Check that we have an App ID to set the Icon
-if ($intuneApp -and $intuneApp.id) {
+    # --- Acquire icon BEFORE creating the app ---
     Write-Verbose "Looking for an App Icon in working folder"
     $iconFile = Get-ChildItem -Path $zipFolder -Filter "*.png" -File | Select-Object -First 1
 
@@ -319,17 +285,50 @@ if ($intuneApp -and $intuneApp.id) {
         }
     }
 
+    $iconObject = $null
     if ($iconFile) {
         Write-Verbose "Found PNG icon: $($iconFile.FullName)"
-        $iconBase64 = New-IntuneWin32AppIcon -FilePath $iconFile.FullName
-        Write-Verbose "Converted PNG to base64"
-        Set-IntuneWin32App -ID $intuneApp.id -Icon $iconBase64 -ErrorAction Stop
-        Write-Verbose "App Icon set successfully."
+        $iconObject = New-IntuneWin32AppIcon -FilePath $iconFile.FullName
+        Write-Verbose "Converted PNG to icon object"
     }
-    else{
-        Write-Verbose "No App Icon found successfully. Skipping setting App ICON"
+    else {
+        Write-Verbose "No App Icon found. Skipping icon assignment."
     }
-}
+
+    # Add Win32 App
+    $appParams = @{
+        FilePath                  = $intuneWinFile.Path
+        DisplayName               = $Config.DisplayName
+        Description               = $Config.Description
+        Publisher                 = $Config.Publisher
+        AppVersion                = $appVersion
+        InformationURL            = $Config.InformationURL
+        InstallExperience         = "system"
+        RequirementRule           = $requirementRule
+        AdditionalRequirementRule = $requirementRegistryRule
+        RestartBehavior           = "basedOnReturnCode"
+        DetectionRule             = $detectionRule
+        InstallCommandLine        = $installCommandLine
+        UninstallCommandLine      = $uninstallCommandLine
+    }
+    if ($iconObject) {
+        $appParams['Icon'] = $iconObject
+    }
+
+    Write-Verbose "Adding Win32 app to Intune..."
+
+    $addAppParams = @{
+            ErrorAction = 'Stop'
+    }
+
+    if ($UseAzCopy) {
+    $addAppParams['UseAzCopy']         = $true
+    $addAppParams['AzCopyWindowStyle'] = 'hidden'
+    }
+
+    $intuneApp = Add-IntuneWin32App @appParams @addAppParams -Verbose
+    #$intuneApp = Add-IntuneWin32App @appParams -ErrorAction Stop -UseAzCopy -AzCopyWindowStyle hidden -Verbose #6>$null #-UseAzCopy -AzCopyWindowStyle hidden -UseAzCopy
+    Write-Verbose "Win32 app added successfully. App ID: $($intuneApp.id)"
 
 }
 catch
@@ -373,4 +372,3 @@ finally
 
     Write-Verbose "Total Script $($runTimeFormatted)"
 }
-

--- a/Win32 Apps/Commercial_Vantage/New-CommercialVantageWin32.ps1
+++ b/Win32 Apps/Commercial_Vantage/New-CommercialVantageWin32.ps1
@@ -58,6 +58,7 @@
                          Replace Write-Output with Write-Verbose/Write-Warning throughout
                          Fix inconsistent brace style in install command logic
     2.2.1 - (2026-07-09) Demote no-local-PNG icon fallback from Write-Warning to Write-Verbose
+    2.2.2 - (2026-08-03) Refactor icon retrieval and assignment logic
 
     Requires a Microsoft Entra app registration with DeviceManagementApps.ReadWrite.All permissions.
     Reference: https://github.com/MSEndpointMgr/IntuneWin32App/issues/156


### PR DESCRIPTION
### Setting Intune App icon fails.

Current logic is incorrect, as the Intune modules can not set the icon after the app is registered. App is created but Icon is missing and error is throw, as seen below:

<img width="645" height="244" alt="image" src="https://github.com/user-attachments/assets/34473f27-f6d1-46c5-9692-2db9fe828e1f" />

- Reorder the logic and move the Code blocks
- Looks for Icon first and if found adds a Check to the Params to set at time of creation.

<img width="800" height="142" alt="image" src="https://github.com/user-attachments/assets/fb0d25fc-3d9d-4e5d-9aea-0903676b40c2" />

Issue:

- #16 